### PR TITLE
NaN invalid JSON

### DIFF
--- a/json_exporter.go
+++ b/json_exporter.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/kawamuray/prometheus-exporter-harness/harness"
-	"github.com/JalfResi/prometheus-json-exporter/jsonexporter"
+	"github.com/kawamuray/prometheus-json-exporter/jsonexporter"
 )
 
 func main() {

--- a/json_exporter.go
+++ b/json_exporter.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/kawamuray/prometheus-exporter-harness/harness"
-	"github.com/kawamuray/prometheus-json-exporter/jsonexporter"
+	"github.com/JalfResi/prometheus-exporter-harness/harness"
+	"github.com/JalfResi/prometheus-json-exporter/jsonexporter"
 )
 
 func main() {

--- a/json_exporter.go
+++ b/json_exporter.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/JalfResi/prometheus-exporter-harness/harness"
+	"github.com/kawamuray/prometheus-exporter-harness/harness"
 	"github.com/JalfResi/prometheus-json-exporter/jsonexporter"
 )
 

--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -53,8 +53,6 @@ func NewCollector(endpoint string, scrapers []JsonScraper) *Collector {
 }
 
 func (col *Collector) fetchJson() ([]byte, error) {
-	log.Infof("Fetching JSON...")
-
 	resp, err := http.Get(col.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch json from endpoint;endpoint:<%s>,err:<%s>", col.Endpoint, err)
@@ -66,14 +64,11 @@ func (col *Collector) fetchJson() ([]byte, error) {
 		return nil, fmt.Errorf("failed to read response body;err:<%s>", err)
 	}
 
-	log.Infof("Tidying...")
-
 	return col.tidyJson(data), nil
 }
 
 func (col *Collector) tidyJson(b []byte) ([]byte) {
-	log.Infof("Replacing NaN with null")
-	return bytes.Replace(b, []byte(": NaN"), []byte(": null"), -1)
+	return bytes.Replace(b, []byte(": NaN"), []byte(": \"NaN\""), -1)
 }
 
 func (col *Collector) Collect(reg *harness.MetricRegistry) {

--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -1,6 +1,7 @@
 package jsonexporter
 
 import (
+	"bytes"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/kawamuray/jsonpath" // Originally: "github.com/NickSardo/jsonpath"
@@ -52,6 +53,8 @@ func NewCollector(endpoint string, scrapers []JsonScraper) *Collector {
 }
 
 func (col *Collector) fetchJson() ([]byte, error) {
+	log.Infof("Fetching JSON...")
+
 	resp, err := http.Get(col.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch json from endpoint;endpoint:<%s>,err:<%s>", col.Endpoint, err)
@@ -63,7 +66,14 @@ func (col *Collector) fetchJson() ([]byte, error) {
 		return nil, fmt.Errorf("failed to read response body;err:<%s>", err)
 	}
 
-	return data, nil
+	log.Infof("Tidying...")
+
+	return col.tidyJson(data), nil
+}
+
+func (col *Collector) tidyJson(b []byte) ([]byte) {
+	log.Infof("Replacing NaN with null")
+	return bytes.Replace(b, []byte(": NaN"), []byte(": null"), -1)
 }
 
 func (col *Collector) Collect(reg *harness.MetricRegistry) {

--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -68,7 +68,7 @@ func (col *Collector) fetchJson() ([]byte, error) {
 }
 
 func (col *Collector) tidyJson(b []byte) ([]byte) {
-	return bytes.Replace(b, []byte(": NaN"), []byte(": \"NaN\""), -1)
+	return bytes.Replace(b, []byte(": NaN"), []byte(": null"), -1)
 }
 
 func (col *Collector) Collect(reg *harness.MetricRegistry) {


### PR DESCRIPTION
I've come across situations in the wild where some services return NaN as a value, which is invalid JSON.

For example:

```json
    {
      "name": "metrics:name=hs2_avg_active_session_time",
      "modelerType": "com.codahale.metrics.JmxReporter$JmxGauge",
      "Value": NaN
    },
```

Should be:

```json
    {
      "name": "metrics:name=hs2_avg_active_session_time",
      "modelerType": "com.codahale.metrics.JmxReporter$JmxGauge",
      "Value": "NaN"
    },
```

I understand that formatting and correcting invalid JSON is not the core responsibility of this project, and should probably be spun out into a separate Dirty JSON parser, but I thought you might find the contribution useful.