### PR TITLE
jsonexporter/scraper: add bool support

### DIFF
--- a/jsonexporter/scraper.go
+++ b/jsonexporter/scraper.go
@@ -67,6 +67,7 @@ func (vs *ValueScraper) Scrape(data []byte, reg *harness.MetricRegistry) error {
 		isFirst = false
 
 		var value float64
+		var boolValue bool
 		var err error
 		switch result.Type {
 		case jsonpath.JsonNumber:
@@ -76,6 +77,12 @@ func (vs *ValueScraper) Scrape(data []byte, reg *harness.MetricRegistry) error {
 			value, err = vs.parseValue(result.Value[1 : len(result.Value)-1])
 		case jsonpath.JsonNull:
 			value = math.NaN()
+		case jsonpath.JsonBool:
+			if boolValue, err = strconv.ParseBool(string(result.Value)); boolValue {
+				value = 1
+			} else {
+				value = 0
+			}
 		default:
 			log.Warnf("skipping not numerical result;path:<%s>,value:<%s>",
 				vs.valueJsonPath, result.Value)


### PR DESCRIPTION
This adds boolean-parsing support to the exporter, which is already provided by the `jsonpath` library. 

Previously json input, such as the one provided by the rspamd stat endpoint could not be fully parsed:
```json
/* shortened response */
{
  "read_only": false,
  "scanned": 364200,
  "learned": 9484
}
```

The boolean values true and false are interpreted in correspondence with other metrics, such as the basic prometheus `up` metric.

/cc @globin