### PR TITLE
Add functionality to add headers to the request

### DIFF
--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -25,6 +25,7 @@ import (
 
 type Collector struct {
 	Endpoint string
+	headers []Header
 	scrapers []JsonScraper
 }
 
@@ -58,15 +59,23 @@ func compilePaths(paths map[string]string) (map[string]*jsonpath.Path, error) {
 	return compiledPaths, nil
 }
 
-func NewCollector(endpoint string, scrapers []JsonScraper) *Collector {
+func NewCollector(endpoint string, headers []Header, scrapers []JsonScraper) *Collector {
 	return &Collector{
 		Endpoint: endpoint,
+		headers: headers,
 		scrapers: scrapers,
 	}
 }
 
 func (col *Collector) fetchJson() ([]byte, error) {
-	resp, err := http.Get(col.Endpoint)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", col.Endpoint, nil)
+	for _, header := range col.headers {
+		for key, value := range header {
+			req.Header.Add(key, value)
+		}
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch json from endpoint;endpoint:<%s>,err:<%s>", col.Endpoint, err)
 	}

--- a/jsonexporter/config.go
+++ b/jsonexporter/config.go
@@ -19,42 +19,54 @@ import (
 	"io/ioutil"
 )
 
-type Config struct {
-	Name   string            `yaml:"name"`
-	Path   string            `yaml:"path"`
-	Labels map[string]string `yaml:"labels"`
-	Type   string            `yaml:"type"`
-	Help   string            `yaml:"help"`
-	Values map[string]string `yaml:"values"`
+// Metric contains values that define a metric
+type Metric struct {
+	Name   string
+	Path   string
+	Labels map[string]string
+	Type   string
+	Help   string
+	Values map[string]string
 }
 
-func (config *Config) labelNames() []string {
-	labelNames := make([]string, 0, len(config.Labels))
-	for name := range config.Labels {
+// Header containes a key and a value for a header
+type Header map[string]string
+
+// Config contains metrics and headers defining
+// a configuration
+type Config struct {
+	Headers []Header         
+	Metrics []Metric
+}
+
+func (metric *Metric) labelNames() []string {
+	labelNames := make([]string, 0, len(metric.Labels))
+	for name := range metric.Labels {
 		labelNames = append(labelNames, name)
 	}
 	return labelNames
 }
 
-func loadConfig(configPath string) ([]*Config, error) {
+func loadConfig(configPath string) (*Config, error) {
 	data, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config;path:<%s>,err:<%s>", configPath, err)
 	}
 
-	var configs []*Config
-	if err := yaml.Unmarshal(data, &configs); err != nil {
+	var config *Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse yaml;err:<%s>", err)
 	}
-	// Complete defaults
-	for _, config := range configs {
-		if config.Type == "" {
-			config.Type = DefaultScrapeType
+
+	// Complete Defaults
+	for i := 0; i < len(config.Metrics); i++ {
+		if config.Metrics[i].Type == "" {
+			config.Metrics[i].Type = DefaultScrapeType
 		}
-		if config.Help == "" {
-			config.Help = config.Name
+		if config.Metrics[i].Help == "" {
+			config.Metrics[i].Help = config.Metrics[i].Name
 		}
 	}
 
-	return configs, nil
+	return config, nil
 }

--- a/jsonexporter/scraper.go
+++ b/jsonexporter/scraper.go
@@ -29,18 +29,18 @@ type JsonScraper interface {
 }
 
 type ValueScraper struct {
-	*Config
+	*Metric
 	valueJsonPath *jsonpath.Path
 }
 
-func NewValueScraper(config *Config) (JsonScraper, error) {
-	valuepath, err := compilePath(config.Path)
+func NewValueScraper(metric *Metric) (JsonScraper, error) {
+	valuepath, err := compilePath(metric.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse path;path:<%s>,err:<%s>", config.Path, err)
+		return nil, fmt.Errorf("failed to parse path;path:<%s>,err:<%s>", metric.Path, err)
 	}
 
 	scraper := &ValueScraper{
-		Config:        config,
+		Metric:        metric,
 		valueJsonPath: valuepath,
 	}
 	return scraper, nil
@@ -119,17 +119,17 @@ type ObjectScraper struct {
 	valueJsonPaths map[string]*jsonpath.Path
 }
 
-func NewObjectScraper(config *Config) (JsonScraper, error) {
-	valueScraper, err := NewValueScraper(config)
+func NewObjectScraper(metric *Metric) (JsonScraper, error) {
+	valueScraper, err := NewValueScraper(metric)
 	if err != nil {
 		return nil, err
 	}
 
-	labelPaths, err := compilePaths(config.Labels)
+	labelPaths, err := compilePaths(metric.Labels)
 	if err != nil {
 		return nil, err
 	}
-	valuePaths, err := compilePaths(config.Values)
+	valuePaths, err := compilePaths(metric.Values)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I have an endpoint where I need to set the `Accept` Http Header to `application/json` otherwise the endpoint wouldn't return anything. I tried to implement it into this project without any go knowledge, so if there are things that should be done differently please tell me.
What I basically did was to put the metrics settings into its own key:
```
# So instead of:
- name: example_global_value
  path: $.counter
  labels:
    environment: beta # static label
# Its:
metrics:
  - name: example_global_value
    path: $.counter
    labels:
      environment: beta # static label
```
And then I added a header key which also holds an array with key and values, which represent the header and the value for the header:
```
# So to set the Accept Header:
headers:
  - Accept: application/json
```
This could open many more possibilities to this exporter so I would be very happy if this functionality could be merged or implemented in any other form. Thank you for your time.