### PR TITLE
Fix bool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,19 @@ $ cat example/data.json
         {
             "id": "id-A",
             "count": 1,
+            "some_boolean": true,
             "state": "ACTIVE"
         },
         {
             "id": "id-B",
             "count": 2,
+            "some_boolean": true,
             "state": "INACTIVE"
         },
         {
             "id": "id-C",
             "count": 3,
+            "some_boolean": false,
             "state": "ACTIVE"
         },
     ]
@@ -50,20 +53,25 @@ $ cat example/config.yml
   values:
     active: 1      # static value
     count: $.count # dynamic value
+    boolean: $.some_boolean
 
 $ python -m SimpleHTTPServer 8000 &
 Serving HTTP on 0.0.0.0 port 8000 ...
 
 $ ./json_exporter http://localhost:8000/example/data.json example/config.yml &
 INFO[2016-02-08T22:44:38+09:00] metric registered;name:<example_global_value>
+INFO[2016-02-08T22:44:38+09:00] metric registered;name:<example_value_boolean>
 INFO[2016-02-08T22:44:38+09:00] metric registered;name:<example_value_active>
 INFO[2016-02-08T22:44:38+09:00] metric registered;name:<example_value_count>
 127.0.0.1 - - [08/Feb/2016 22:44:38] "GET /example/data.json HTTP/1.1" 200 -
+
 
 $ curl http://localhost:7979/metrics | grep ^example
 example_global_value{environment="beta"} 1234
 example_value_active{environment="beta",id="id-A"} 1
 example_value_active{environment="beta",id="id-C"} 1
+example_value_boolean{environment="beta",id="id-A"} 1
+example_value_boolean{environment="beta",id="id-C"} 0
 example_value_count{environment="beta",id="id-A"} 1
 example_value_count{environment="beta",id="id-C"} 3
 ```

--- a/example/config.yml
+++ b/example/config.yml
@@ -12,3 +12,4 @@
   values:
     active: 1      # static value
     count: $.count # dynamic value
+    boolean: $.some_boolean

--- a/example/data.json
+++ b/example/data.json
@@ -4,16 +4,19 @@
         {
             "id": "id-A",
             "count": 1,
+            "some_boolean": true,
             "state": "ACTIVE"
         },
         {
             "id": "id-B",
             "count": 2,
+            "some_boolean": true,
             "state": "INACTIVE"
         },
         {
             "id": "id-C",
             "count": 3,
+            "some_boolean": false,
             "state": "ACTIVE"
         },
     ]

--- a/jsonexporter/scraper.go
+++ b/jsonexporter/scraper.go
@@ -209,6 +209,7 @@ func (obsc *ObjectScraper) Scrape(data []byte, reg *harness.MetricRegistry) erro
 				}
 
 				var value float64
+				var boolValue bool
 				switch firstResult.Type {
 				case jsonpath.JsonNumber:
 					value, err = obsc.parseValue(firstResult.Value)
@@ -217,6 +218,12 @@ func (obsc *ObjectScraper) Scrape(data []byte, reg *harness.MetricRegistry) erro
 					value, err = obsc.parseValue(firstResult.Value[1 : len(firstResult.Value)-1])
 				case jsonpath.JsonNull:
 					value = math.NaN()
+				case jsonpath.JsonBool:
+					if boolValue, err = strconv.ParseBool(string(firstResult.Value)); boolValue {
+						value = 1.0
+					} else {
+						value = 0.0
+					}
 				default:
 					log.Warnf("skipping not numerical result;path:<%v>,value:<%s>",
 						obsc.valueJsonPath, result.Value)


### PR DESCRIPTION
This fixes parsing of boolean values.

Boolean support was added thanks to #17, but was incomplete. Consider the following example JSON:

```
{
    "counter": 1234,
    "values": [
        {
            "id": "id-A",
            "count": 1,
            "some_boolean": true,
            "state": "ACTIVE"
        },
        {
            "id": "id-B",
            "count": 2,
            "some_boolean": true,
            "state": "INACTIVE"
        },
        {
            "id": "id-C",
            "count": 3,
            "some_boolean": false,
            "state": "ACTIVE"
        },
    ]
}
```

This previously yielded a "skipping not numerical result" error.

This PR corrects this, and also updates the example and README to demo the boolean parsing.

/cc @WilliButz 