### PR TITLE
Dockerfile for multi-stage build

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,0 +1,28 @@
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM golang:1.14-alpine as builder
+
+ARG ARCH
+ARG OS
+
+WORKDIR /build
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY . ./
+RUN CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -a -tags netgo -o json_exporter-${OS}-${ARCH}
+
+ARG ARCH
+ARG OS
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:glibc
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+
+ARG ARCH
+ARG OS
+
+COPY --from=builder /build/json_exporter-${OS}-${ARCH} /bin/json_exporter
+
+EXPOSE      7979
+USER        nobody
+ENTRYPOINT  [ "/bin/json_exporter" ]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ A [prometheus](https://prometheus.io/) exporter which scrapes remote JSON by JSO
 make build
 ```
 
+Instead, if you just manually want to build a Docker image, use a multi-stage build:
+
+```sh
+docker build -t json-exporter:dev -f ./Dockerfile.multi --build-arg ARCH="amd64" --build-arg OS="linux" .
+```
+
+
 # Example Usage
 
 ```sh


### PR DESCRIPTION
The existing Dockerfile is tightly coupled to the build process and requires the `json_exporter` executable to be built outside of Docker first.

This PR proposes a second Dockerfile, `Dockerfile.multi`, to allow users to easily build a Docker image locally: thanks to the multi-stage build process the build happens entirely in Docker.