### PR TITLE
Add functionality to add headers to the request

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -1,3 +1,5 @@
+---
+metrics:
 - name: example_global_value
   path: $.counter
   labels:
@@ -13,3 +15,6 @@
     active: 1      # static value
     count: $.count # dynamic value
     boolean: $.some_boolean
+
+headers:
+  X-Dummy: my-test-header

--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -73,6 +73,9 @@ func (col *Collector) fetchJson() ([]byte, error) {
 	for key, value := range col.headers {
 		req.Header.Add(key, value)
 	}
+	if req.Header.Get("Accept") == "" {
+		req.Header.Add("Accept", "application/json")
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch json from endpoint;endpoint:<%s>,err:<%s>", col.Endpoint, err)

--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -25,7 +25,7 @@ import (
 
 type Collector struct {
 	Endpoint string
-	headers []Header
+	headers  map[string]string
 	scrapers []JsonScraper
 }
 
@@ -59,10 +59,10 @@ func compilePaths(paths map[string]string) (map[string]*jsonpath.Path, error) {
 	return compiledPaths, nil
 }
 
-func NewCollector(endpoint string, headers []Header, scrapers []JsonScraper) *Collector {
+func NewCollector(endpoint string, headers map[string]string, scrapers []JsonScraper) *Collector {
 	return &Collector{
 		Endpoint: endpoint,
-		headers: headers,
+		headers:  headers,
 		scrapers: scrapers,
 	}
 }
@@ -70,10 +70,8 @@ func NewCollector(endpoint string, headers []Header, scrapers []JsonScraper) *Co
 func (col *Collector) fetchJson() ([]byte, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", col.Endpoint, nil)
-	for _, header := range col.headers {
-		for key, value := range header {
-			req.Header.Add(key, value)
-		}
+	for key, value := range col.headers {
+		req.Header.Add(key, value)
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/jsonexporter/collector.go
+++ b/jsonexporter/collector.go
@@ -25,6 +25,7 @@ import (
 
 type Collector struct {
 	Endpoint string
+	headers []Header
 	scrapers []JsonScraper
 }
 
@@ -58,15 +59,23 @@ func compilePaths(paths map[string]string) (map[string]*jsonpath.Path, error) {
 	return compiledPaths, nil
 }
 
-func NewCollector(endpoint string, scrapers []JsonScraper) *Collector {
+func NewCollector(endpoint string, headers []Header, scrapers []JsonScraper) *Collector {
 	return &Collector{
 		Endpoint: endpoint,
+		headers: headers,
 		scrapers: scrapers,
 	}
 }
 
 func (col *Collector) fetchJson() ([]byte, error) {
-	resp, err := http.Get(col.Endpoint)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", col.Endpoint, nil)
+	for _, header := range col.headers {
+		for key, value := range header {
+			req.Header.Add(key, value)
+		}
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch json from endpoint;endpoint:<%s>,err:<%s>", col.Endpoint, err)
 	}

--- a/jsonexporter/config.go
+++ b/jsonexporter/config.go
@@ -15,8 +15,9 @@ package jsonexporter
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 // Metric contains values that define a metric
@@ -29,13 +30,9 @@ type Metric struct {
 	Values map[string]string
 }
 
-// Header containes a key and a value for a header
-type Header map[string]string
-
-// Config contains metrics and headers defining
-// a configuration
+// Config contains metrics and headers defining a configuration
 type Config struct {
-	Headers []Header         
+	Headers map[string]string
 	Metrics []Metric
 }
 

--- a/jsonexporter/config.go
+++ b/jsonexporter/config.go
@@ -19,42 +19,54 @@ import (
 	"io/ioutil"
 )
 
-type Config struct {
-	Name   string            `yaml:"name"`
-	Path   string            `yaml:"path"`
-	Labels map[string]string `yaml:"labels"`
-	Type   string            `yaml:"type"`
-	Help   string            `yaml:"help"`
-	Values map[string]string `yaml:"values"`
+// Metric contains values that define a metric
+type Metric struct {
+	Name   string
+	Path   string
+	Labels map[string]string
+	Type   string
+	Help   string
+	Values map[string]string
 }
 
-func (config *Config) labelNames() []string {
-	labelNames := make([]string, 0, len(config.Labels))
-	for name := range config.Labels {
+// Header containes a key and a value for a header
+type Header map[string]string
+
+// Config contains metrics and headers defining
+// a configuration
+type Config struct {
+	Headers []Header         
+	Metrics []Metric
+}
+
+func (metric *Metric) labelNames() []string {
+	labelNames := make([]string, 0, len(metric.Labels))
+	for name := range metric.Labels {
 		labelNames = append(labelNames, name)
 	}
 	return labelNames
 }
 
-func loadConfig(configPath string) ([]*Config, error) {
+func loadConfig(configPath string) (*Config, error) {
 	data, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config;path:<%s>,err:<%s>", configPath, err)
 	}
 
-	var configs []*Config
-	if err := yaml.Unmarshal(data, &configs); err != nil {
+	var config *Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse yaml;err:<%s>", err)
 	}
-	// Complete defaults
-	for _, config := range configs {
-		if config.Type == "" {
-			config.Type = DefaultScrapeType
+
+	// Complete Defaults
+	for i := 0; i < len(config.Metrics); i++ {
+		if config.Metrics[i].Type == "" {
+			config.Metrics[i].Type = DefaultScrapeType
 		}
-		if config.Help == "" {
-			config.Help = config.Name
+		if config.Metrics[i].Help == "" {
+			config.Metrics[i].Help = config.Metrics[i].Name
 		}
 	}
 
-	return configs, nil
+	return config, nil
 }

--- a/jsonexporter/init.go
+++ b/jsonexporter/init.go
@@ -82,8 +82,8 @@ func Init(c *cli.Context, reg *harness.MetricRegistry) (harness.Collector, error
 		if tpe == nil {
 			return nil, fmt.Errorf("unknown scrape type;type:<%s>", metric.Type)
 		}
-		tpe.Configure(&metric, reg)
-		scraper, err := tpe.NewScraper(&metric)
+		tpe.Configure(&config.Metrics[i], reg)
+		scraper, err := tpe.NewScraper(&config.Metrics[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to create scraper;name:<%s>,err:<%s>", metric.Name, err)
 		}

--- a/jsonexporter/scraper.go
+++ b/jsonexporter/scraper.go
@@ -29,18 +29,18 @@ type JsonScraper interface {
 }
 
 type ValueScraper struct {
-	*Config
+	*Metric
 	valueJsonPath *jsonpath.Path
 }
 
-func NewValueScraper(config *Config) (JsonScraper, error) {
-	valuepath, err := compilePath(config.Path)
+func NewValueScraper(metric *Metric) (JsonScraper, error) {
+	valuepath, err := compilePath(metric.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse path;path:<%s>,err:<%s>", config.Path, err)
+		return nil, fmt.Errorf("failed to parse path;path:<%s>,err:<%s>", metric.Path, err)
 	}
 
 	scraper := &ValueScraper{
-		Config:        config,
+		Metric:        metric,
 		valueJsonPath: valuepath,
 	}
 	return scraper, nil
@@ -119,17 +119,17 @@ type ObjectScraper struct {
 	valueJsonPaths map[string]*jsonpath.Path
 }
 
-func NewObjectScraper(config *Config) (JsonScraper, error) {
-	valueScraper, err := NewValueScraper(config)
+func NewObjectScraper(metric *Metric) (JsonScraper, error) {
+	valueScraper, err := NewValueScraper(metric)
 	if err != nil {
 		return nil, err
 	}
 
-	labelPaths, err := compilePaths(config.Labels)
+	labelPaths, err := compilePaths(metric.Labels)
 	if err != nil {
 		return nil, err
 	}
-	valuePaths, err := compilePaths(config.Values)
+	valuePaths, err := compilePaths(metric.Values)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Based on #30 with following changes:

* Update the example config to use `headers` as well as the `metrics` keys in alignment with the new code
* Change the header config from a list to a map.
  From:
  ```
  headers:
    - X-Dummy: my-header
    - X-Test: another-header
  ```
  To:
  ```
  headers:
    X-Dummy: my-header
    X-Test: another-header
  ```
* Fix the bug where the new header feature wasn't working because of passing wrong pointers
* Add default header `Accept: application/json`