### PR TITLE
Add support for turning off TLS verification for scraped sites

### DIFF
--- a/harness/main.go
+++ b/harness/main.go
@@ -30,6 +30,10 @@ var (
 			Usage: "Set Logging level",
 			Value: "info",
 		},
+		cli.BoolFlag{
+			Name:  "tls.insecure-skip-verify",
+			Usage: "Ignore certificate verifications",
+		},
 	}
 
 	defaultTickOpt = cli.IntFlag{

--- a/jsonexporter/init.go
+++ b/jsonexporter/init.go
@@ -60,7 +60,7 @@ var DefaultScrapeType = "value"
 
 func Init(c *cli.Context, reg *harness.MetricRegistry) (harness.Collector, error) {
 	args := c.Args()
-
+	insecure := c.Bool("tls.insecure-skip-verify")
 	if len(args) < 2 {
 		cli.ShowAppHelp(c) //nolint:errcheck
 		return nil, fmt.Errorf("not enough arguments")
@@ -90,5 +90,5 @@ func Init(c *cli.Context, reg *harness.MetricRegistry) (harness.Collector, error
 		scrapers[i] = scraper
 	}
 
-	return NewCollector(endpoint, scrapers), nil
+	return NewCollector(endpoint, insecure, scrapers), nil
 }


### PR DESCRIPTION
Pull request 12 seems to be abandoned so I went ahead and cleaned it up based on @SuperQ's feedback to it. 