### PR TITLE
Fix unchecked call to io.Copy

### DIFF
--- a/exporter/util.go
+++ b/exporter/util.go
@@ -159,7 +159,9 @@ func FetchJson(ctx context.Context, logger log.Logger, endpoint string, config c
 	}
 
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+			level.Error(logger).Log("msg", "Failed to discard body", "err", err) //nolint:errcheck
+		}
 		resp.Body.Close()
 	}()
 


### PR DESCRIPTION
After #49 was merged to master the build failed due to a linting error:

    GO111MODULE=on /go/bin/golangci-lint run  ./...
    exporter/util.go:162:10: Error return value of `io.Copy` is not checked
    (errcheck)
                    io.Copy(ioutil.Discard, resp.Body)
                           ^
    make: *** [Makefile.common:192: common-lint] Error 1

build failure here:
https://app.circleci.com/pipelines/github/prometheus-community/json_exporter/28/workflows/e2c53db3-d3a3-4faa-a5a6-3b1fbb5754a0/jobs/71