### PR TITLE
Add k8s.io/client-go exlude list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,29 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/client-go v0.20.2
 )
+
+exclude (
+	// Exclude pre-go-mod kubernetes tags, as they are older
+	// than v0.x releases but are picked when we update the dependencies.
+	k8s.io/client-go v1.4.0
+	k8s.io/client-go v1.4.0+incompatible
+	k8s.io/client-go v1.5.0
+	k8s.io/client-go v1.5.0+incompatible
+	k8s.io/client-go v1.5.1
+	k8s.io/client-go v1.5.1+incompatible
+	k8s.io/client-go v10.0.0+incompatible
+	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/client-go v2.0.0+incompatible
+	k8s.io/client-go v2.0.0-alpha.1+incompatible
+	k8s.io/client-go v3.0.0+incompatible
+	k8s.io/client-go v3.0.0-beta.0+incompatible
+	k8s.io/client-go v4.0.0+incompatible
+	k8s.io/client-go v4.0.0-beta.0+incompatible
+	k8s.io/client-go v5.0.0+incompatible
+	k8s.io/client-go v5.0.1+incompatible
+	k8s.io/client-go v6.0.0+incompatible
+	k8s.io/client-go v7.0.0+incompatible
+	k8s.io/client-go v8.0.0+incompatible
+	k8s.io/client-go v9.0.0+incompatible
+	k8s.io/client-go v9.0.0-invalid+incompatible
+)


### PR DESCRIPTION
Add a similar exclude list to prometheus/prometheus to exclude
pre go modules k8s.io/client-go[0]. This allows easy use of
`make update-go-deps`.

[0]: https://github.com/prometheus/prometheus/blob/89e9632a34a18ebbf9e3f944a8cd0867a8bf63ef/go.mod#L94-L116

Signed-off-by: Ben Kochie <superq@gmail.com>