### PR TITLE
Add release date to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0
+## 0.3.0 / 2021-02-12
 
 :warning: Backward incompatible configuration with previous versions.
 * [CHANGE] Migrate JSONPath library [#74](https://github.com/prometheus-community/json_exporter/pull/74)


### PR DESCRIPTION
For fixing CI:
```
#!/bin/bash -eo pipefail
promu release .tarballs

!! unable to locate release information in changelog for version "0.3.0", expected format: "^#{1,2} 0\\.3\\.0 / (\\d{4}-\\d{2}-\\d{2})"

Exited with code exit status 1
CircleCI received exit code 1
```

Although I don't see why having the date in the changelog is mandatory.