### PR TITLE
Use explicit metric type switching

### DIFF
--- a/exporter/util.go
+++ b/exporter/util.go
@@ -73,6 +73,7 @@ func CreateMetricsList(c config.Config) ([]JSONMetric, error) {
 				variableLabelsValues = append(variableLabelsValues, v)
 			}
 			jsonMetric := JSONMetric{
+				Type: config.ValueScrape,
 				Desc: prometheus.NewDesc(
 					metric.Name,
 					metric.Help,
@@ -92,6 +93,7 @@ func CreateMetricsList(c config.Config) ([]JSONMetric, error) {
 					variableLabelsValues = append(variableLabelsValues, v)
 				}
 				jsonMetric := JSONMetric{
+					Type: config.ObjectScrape,
 					Desc: prometheus.NewDesc(
 						name,
 						metric.Help,


### PR DESCRIPTION
Avoid side effect behavior by explicitly passing the ScrypeType to the
collector.

Signed-off-by: SuperQ <superq@gmail.com>