### PR TITLE
Add ignore_status

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ type Module struct {
 	Metrics          []Metric                 `yaml:"metrics"`
 	HTTPClientConfig pconfig.HTTPClientConfig `yaml:"http_client_config,omitempty"`
 	Body             Body                     `yaml:"body,omitempty"`
+	IgnoreStatus     bool                     `yaml:"ignore_status,omitempty"`
 }
 
 type Body struct {

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,7 @@ type Module struct {
 	Metrics          []Metric                 `yaml:"metrics"`
 	HTTPClientConfig pconfig.HTTPClientConfig `yaml:"http_client_config,omitempty"`
 	Body             Body                     `yaml:"body,omitempty"`
-	IgnoreStatus     bool                     `yaml:"ignore_status,omitempty"`
+	ValidStatusCodes []int                    `yaml:"valid_status_codes,omitempty"`
 }
 
 type Body struct {

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -43,3 +43,6 @@ modules:
     #     username: myuser
     #     #password: veryverysecret
     #     password_file: /tmp/mysecret.txt
+
+    # Do not fail target scrape in case of non-2xx http status, still try to parse json from the response.
+    # ignore_status: true

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -44,5 +44,5 @@ modules:
     #     #password: veryverysecret
     #     password_file: /tmp/mysecret.txt
 
-    # Do not fail target scrape in case of non-2xx http status, still try to parse json from the response.
-    # ignore_status: true
+    # Accepted status codes for this probe. Defaults to 2xx.
+    # valid_status_codes: [ <int>, ... | default = 2xx ]

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -179,7 +179,7 @@ func (f *JSONFetcher) FetchJSON(endpoint string) ([]byte, error) {
 		resp.Body.Close()
 	}()
 
-	if resp.StatusCode/100 != 2 {
+	if !f.module.IgnoreStatus && resp.StatusCode/100 != 2 {
 		return nil, errors.New(resp.Status)
 	}
 

--- a/exporter/util.go
+++ b/exporter/util.go
@@ -179,7 +179,18 @@ func (f *JSONFetcher) FetchJSON(endpoint string) ([]byte, error) {
 		resp.Body.Close()
 	}()
 
-	if !f.module.IgnoreStatus && resp.StatusCode/100 != 2 {
+	if len(f.module.ValidStatusCodes) != 0 {
+		success := false
+		for _, code := range f.module.ValidStatusCodes {
+			if resp.StatusCode == code {
+				success = true
+				break
+			}
+		}
+		if !success {
+			return nil, errors.New(resp.Status)
+		}
+	} else if resp.StatusCode/100 != 2 {
 		return nil, errors.New(resp.Status)
 	}
 


### PR DESCRIPTION
Fix for: #160
It seems this option would look better inside of `http_client_config`, but I do not see easy way to extend `HTTPClientConfig` (because it has own `UnmarshalJSON()`)