### PR TITLE
Construct Prometheus Metrics with ValueType

### DIFF
--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -59,7 +59,7 @@ func (mc JSONMetricCollector) Collect(ch chan<- prometheus.Metric) {
 
 				ch <- prometheus.MustNewConstMetric(
 					m.Desc,
-					prometheus.UntypedValue,
+					m.ValueType,
 					floatValue,
 					extractLabels(mc.Logger, mc.Data, m.LabelsJSONPaths)...,
 				)
@@ -92,7 +92,7 @@ func (mc JSONMetricCollector) Collect(ch chan<- prometheus.Metric) {
 					if floatValue, err := SanitizeValue(value); err == nil {
 						ch <- prometheus.MustNewConstMetric(
 							m.Desc,
-							prometheus.UntypedValue,
+							m.ValueType,
 							floatValue,
 							extractLabels(mc.Logger, jdata, m.LabelsJSONPaths)...,
 						)


### PR DESCRIPTION
I noticed that on the master branch, you'd see the following information once you were set up with the example:

```
# HELP example_global_value Example of a top-level global value scrape in the json
# TYPE example_global_value untyped
example_global_value{environment="beta",location="planet-mars"} 1234
# HELP example_value_active Example of sub-level value scrapes from a json
# TYPE example_value_active untyped
example_value_active{environment="beta",id="id-A"} 1
example_value_active{environment="beta",id="id-C"} 1
```

With this PR, and a corresponding config change to the example like:

```
---
modules:
  default:
    metrics:
    - name: example_global_value
      path: "{ .counter }"
      help: Example of a top-level global value scrape in the json
      valuetype: gauge
      labels:
        environment: beta # static label
        location: "planet-{.location}"          # dynamic label

    - name: example_value
      type: object
      help: Example of sub-level value scrapes from a json
      path: '{.values[?(@.state == "ACTIVE")]}'
      valuetype: counter
      labels:
        environment: beta # static label
        id: '{.id}'          # dynamic label
      values:
        active: 1      # static value
        count: '{.count}' # dynamic value
        boolean: '{.some_boolean}'
    headers:
      X-Dummy: my-test-header
```

The `# TYPE <metric> <valuetype>` ends up correct.

```
# HELP example_global_value Example of a top-level global value scrape in the json
# TYPE example_global_value gauge
example_global_value{environment="beta",location="planet-mars"} 1234
# HELP example_value_active Example of sub-level value scrapes from a json
# TYPE example_value_active counter
example_value_active{environment="beta",id="id-A"} 1
example_value_active{environment="beta",id="id-C"} 1
# HELP example_value_boolean Example of sub-level value scrapes from a json
# TYPE example_value_boolean counter
example_value_boolean{environment="beta",id="id-A"} 1
example_value_boolean{environment="beta",id="id-C"} 0
# HELP example_value_count Example of sub-level value scrapes from a json
# TYPE example_value_count counter
example_value_count{environment="beta",id="id-A"} 1
example_value_count{environment="beta",id="id-C"} 3
```

I'm not 100% sure the code for the `config.ObjectScrape` case is correct - maybe those should default to Untyped?