### PR TITLE
Update example config.yml with valid status code examples

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,6 +1,7 @@
 ---
 modules:
   default:
+    valid_status_codes: [200, 201, 202, 800, 801, 802] # Example of custom status codes
     headers:
       X-Dummy: my-test-header
     metrics:


### PR DESCRIPTION
Modified the valid_status_codes list to include both standard HTTP status codes and custom status codes.
The new configuration now includes [200, 201, 202, 800, 801, 802].

This way is more explanatory and declarative at first sight.