### PR TITLE
fix: fixes duplicated labels

### DIFF
--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -16,10 +16,10 @@ package exporter
 import (
 	"bytes"
 	"encoding/json"
-	"log/slog"
-	"time"
 	"fmt"
+	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/prometheus-community/json_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"


### PR DESCRIPTION
This commit fixes the metric conflicts
https://github.com/prometheus-community/json_exporter/issues/394

in my case, the json_exporter could not resolve the /api/v1/alerts of prometheus instances due to a lot of duplicated labels (e.g. value, annotations, alertname, etc)