### PR TITLE
Render numeric label and value paths without scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [BUGFIX] Render numeric label and value paths without scientific notation #367
+
 ## 0.7.0 / 2025-02-05
 
 * [CHANGE] adopt slog, drop go-kit/log #334

--- a/exporter/collector.go
+++ b/exporter/collector.go
@@ -16,7 +16,10 @@ package exporter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/prometheus-community/json_exporter/config"
@@ -147,20 +150,80 @@ func extractValue(logger *slog.Logger, data []byte, path string, enableJSONOutpu
 		return "", false, err
 	}
 
-	if err := j.Execute(buf, jsonData); err != nil {
+	if enableJSONOutput {
+		if err := j.Execute(buf, jsonData); err != nil {
+			logger.Error("Failed to execute jsonpath", "err", err, "path", path, "data", data)
+			return "", false, err
+		}
+		if buf.Len() == 0 && allowMissingKey {
+			return "", true, nil
+		}
+
+		// Since we are finally going to extract only float64, unquote if necessary
+		if res, err := jsonpath.UnquoteExtend(buf.String()); err == nil {
+			return res, false, nil
+		}
+
+		return buf.String(), false, nil
+	}
+
+	// For the non-JSON-output path we render the results ourselves instead of
+	// relying on jsonpath's default text formatting, which prints float64 values
+	// (all JSON numbers unmarshal to float64) using %v and thus renders large
+	// integers in scientific notation, e.g. "1.655371e+06" instead of "1655371".
+	fullResults, err := j.FindResults(jsonData)
+	if err != nil {
 		logger.Error("Failed to execute jsonpath", "err", err, "path", path, "data", data)
 		return "", false, err
 	}
-	if buf.Len() == 0 && allowMissingKey {
+	out := resultsToText(fullResults)
+	if len(out) == 0 && allowMissingKey {
 		return "", true, nil
 	}
 
 	// Since we are finally going to extract only float64, unquote if necessary
-	if res, err := jsonpath.UnquoteExtend(buf.String()); err == nil {
+	if res, err := jsonpath.UnquoteExtend(out); err == nil {
 		return res, false, nil
 	}
 
-	return buf.String(), false, nil
+	return out, false, nil
+}
+
+// resultsToText renders jsonpath results as space-separated text, formatting
+// float64 leaf values without scientific notation.
+func resultsToText(fullResults [][]reflect.Value) string {
+	buf := new(bytes.Buffer)
+	for _, results := range fullResults {
+		for i, r := range results {
+			text := resultToText(r)
+			if i != len(results)-1 {
+				text = append(text, ' ')
+			}
+			buf.Write(text)
+		}
+	}
+	return buf.String()
+}
+
+func resultToText(r reflect.Value) []byte {
+	v := r
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Map, reflect.Array, reflect.Slice, reflect.Struct:
+		if b, err := json.Marshal(v.Interface()); err == nil {
+			return b
+		}
+	case reflect.Float64, reflect.Float32:
+		return []byte(strconv.FormatFloat(v.Float(), 'f', -1, 64))
+	}
+	if !v.IsValid() {
+		return []byte("<nil>")
+	}
+	var b bytes.Buffer
+	fmt.Fprint(&b, v.Interface())
+	return b.Bytes()
 }
 
 // Returns the list of labels created from the list of provided json paths

--- a/exporter/collector_test.go
+++ b/exporter/collector_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func TestExtractValue(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tests := []struct {
+		Name           string
+		Data           string
+		Path           string
+		ExpectedOutput string
+	}{
+		{
+			Name:           "large integer is not rendered in scientific notation",
+			Data:           `{"id": 1655371}`,
+			Path:           "{ .id }",
+			ExpectedOutput: "1655371",
+		},
+		{
+			Name:           "float keeps decimals without scientific notation",
+			Data:           `{"value": 1234567.89}`,
+			Path:           "{ .value }",
+			ExpectedOutput: "1234567.89",
+		},
+		{
+			Name:           "small integer is unaffected",
+			Data:           `{"count": 42}`,
+			Path:           "{ .count }",
+			ExpectedOutput: "42",
+		},
+		{
+			Name:           "string value is preserved",
+			Data:           `{"name": "foo"}`,
+			Path:           "{ .name }",
+			ExpectedOutput: "foo",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			value, _, err := extractValue(logger, []byte(test.Data), test.Path, false, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if value != test.ExpectedOutput {
+				t.Fatalf("got %q, expected %q", value, test.ExpectedOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #367.

A numeric JSON value used as a label (or metric value) is rendered in scientific notation, e.g. `{"id": 1655371}` produces `id="1.655371e+06"` instead of `id="1655371"`.

## Root cause

`encoding/json` unmarshals every JSON number into `float64`, and `k8s.io/client-go/util/jsonpath` renders scalar results with `fmt.Fprint(..., iface)` (i.e. `%v`), which prints large `float64` values in scientific notation.

## Fix

For the non-JSON-output extraction path (used for label values, `values`, and scalar metric values), `extractValue` now calls `FindResults` and renders the results itself, formatting `float64` leaf values with `strconv.FormatFloat(f, 'f', -1, 64)`. All other kinds keep the previous behavior (containers via `json.Marshal`, everything else via `fmt.Fprint`).

Numeric jsonpath filters such as `[?(@.x>5)]` are unaffected: values remain `float64` during evaluation, and only the final leaf-text rendering changes. The JSON-output path (`ObjectScrape` key extraction) is left untouched to minimize risk.

## Tests

Added `TestExtractValue` covering a large integer, a float with decimals, a small integer, and a string value.

## Changelog

Added a `[BUGFIX]` entry referencing #367.