### PR TITLE
fix: do not require config file for --version and --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [BUGFIX] Do not require a config file to be present when running `--version` or `--help` #292
+
 ## 0.7.0 / 2025-02-05
 
 * [CHANGE] adopt slog, drop go-kit/log #334

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	configFile  = kingpin.Flag("config.file", "JSON exporter configuration file.").Default("config.yml").ExistingFile()
+	configFile  = kingpin.Flag("config.file", "JSON exporter configuration file.").Default("config.yml").String()
 	configCheck = kingpin.Flag("config.check", "If true validate the config file and then exit.").Default("false").Bool()
 	metricsPath = kingpin.Flag(
 		"web.telemetry-path",


### PR DESCRIPTION
## Summary

`json_exporter --version` (and `--help`) fail when no config file is present:

```
# ./json_exporter --version
json_exporter: error: path 'config.yml' does not exist, try --help
```

The `--config.file` flag is defined with `.Default("config.yml").ExistingFile()`, so kingpin validates that `config.yml` exists while parsing flags — before the `--version`/`--help` actions run. This diverges from other Prometheus exporters, where informational flags work without a config file.

## Change

Replace `.ExistingFile()` with `.String()` for the `config.file` flag. A missing config file is still reported clearly at startup by `LoadConfig` (`os.ReadFile`), which already surfaces the error and exits non-zero, so no genuine configuration error is masked.

Fixes #292

## Testing

- No behavioral test added: the change only affects flag-parse-time validation of `--version`/`--help`, which requires exercising the process entry point (the exporter uses `kingpin.Version`/`kingpin.HelpFlag` that call `os.Exit`). Manual verification: with the fix, `--version` and `--help` succeed with no `config.yml` present, while starting the exporter without a config still fails at `LoadConfig` with `open config.yml: no such file or directory`.